### PR TITLE
Docs: fix links, switched week topic, and spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the official repository for the TU Delft graduate elective course focuse
 - [Learning Objectives](#learning-objectives)
 - [Course Structure, Dates and Delivery Locations](#course-structure-dates-and-delivery-locations)
 - [Methods of Examination and Assessment](#methods-of-examination-and-assessment)
-- [Grade Calculation, Repair Assigmnent and Resits](#grade-calculation-repair-assigmnent-and-resits)
+- [Grade Calculation, Repair Assignment and Resits](#grade-calculation-repair-assignment-and-resits)
 - [Dates and Deadlines](#dates-and-deadlines)
 - [This Course is Looking for Your Feedback](#this-course-is-looking-for-your-feedback)
 - [The Course Team](#the-course-team)
@@ -25,7 +25,7 @@ This is the official repository for the TU Delft graduate elective course focuse
 
 There is—and will continue to be—a strong societal need for sustainable ICT systems, encompassing both **sustainable computation** and **sustainable communication**. The labour market increasingly demands ICT professionals who understand the challenges of sustainability and can integrate sustainability goals into system design.
 
-To the best of our knowledge, there are currently no other courses in the Netherlands—or internationally—that comprehensively address this topic. Offering such a course positions TU Delft as a [energy-cautious university](https://www.tudelft.nl/sustainability/about-us/our-vision) that takes sustainability into its curriculum, even in fields not traditionally associated with climate research, such as computer science.
+To the best of our knowledge, there are currently no other courses in the Netherlands—or internationally—that comprehensively address this topic. Offering such a course positions TU Delft as an [energy-cautious university](https://www.tudelft.nl/sustainability/about-us/our-vision) that takes sustainability into its curriculum, even in fields not traditionally associated with climate research, such as computer science.
 
 This course brings together topics covered in other courses and examines them through the lens of sustainable design. It deepens existing subjects (e.g., green software) and introduces new ones not currently addressed in TU Delft’s computer science curriculum (e.g., sustainable electronics design).
 
@@ -37,10 +37,10 @@ To summarize, this course introduces MSc students to the principle that sustaina
 
 At the end of the course, the student is able to: 
 
-1. **List** what are the methods of assessing _ICT industry impact_ on climate.
+1. **List** what the methods are of assessing _ICT industry impact_ on climate.
 2. **Comprehend** the implications of different _ICT systems design decisions_ on the climate.
 3. **Apply techniques** in the ICT system design that allow to _minimize impact on climate_ of the developed system and know how to _make ICT system sustainable_.
-4. **Analyse** how each design ICT system technique _affects ICT system climate impact_.
+4. **Analyse** how each ICT system design technique _affects ICT system climate impact_.
 5. **Create** new methods of ICT system design considering _sustainability as core performance metric_.
 
 ## Course Structure, Dates and Delivery Locations
@@ -108,16 +108,16 @@ All lectures will be given physically at TU Delft, except for guest lectures whi
 
 The course is composed of two assessment methods:
 
-- _Group Project_: A group project where you will be applying some of the knowledge obtained during the course. The outcome of the project will be assessed by submitting a project report and a presenting the outcome of the project during an public presentation at the end of the course. The group project will evaluate whether [learning objectives](#learning-objectives) 3, 4 and 5 have been met by a student.
-- _Written Exam_: A multiple choice exam, assessing your course knowledge. It will evaluate whether [learning objectives](#learning-objectives) 1, 2 and 3 have been met by a sutdent.
+- _Group Project_: A group project where you will be applying some of the knowledge obtained during the course. The outcome of the project will be assessed by submitting a project report and presenting the outcome of the project during a public presentation at the end of the course. The group project will evaluate whether [learning objectives](#learning-objectives) 3, 4 and 5 have been met by a student.
+- _Written Exam_: A multiple choice exam, assessing your course knowledge. It will evaluate whether [learning objectives](#learning-objectives) 1, 2 and 3 have been met by a student.
 
-### Grade Calculation, Repair Assigmnent and Resits
+### Grade Calculation, Repair Assignment and Resits
 
 The final course grade $F$ is calculated as $F=0.6P+0.3E+0.1R$, where $P$ is the final grade for the project report, $E$ is the final grade for the exam and $R$ is the final grade for the project presentation. For $P$, $E$ and $R$ you must obtain at least 5.75 grade to pass the course (see [TU Delft Assessment Framework](https://filelist.tudelft.nl/Calendar/2023/08%20August/Assessment%20framework%20TUD%20-%20final%20%281.3-Sep23%29.pdf), page 41). 
 
-* _Group Project_: In case of grade $P$ for the group project being lower than 5.75 or a student wants to improve the grade $P$, the student must register for the course in the next academic year to repair the grade. In other words, there will be no repair assignment for the group project. This is because the group project will span the whole course time and it will be unreasonable to ask the student to do a failed project in even less time than the academic quarter (see [TU Delft Faculty of Electrical Engineering, Mathematics and Computer Science Teaching and Examination Regulations 2025-2026](https://filelist.tudelft.nl/Studentenportal/Faculteitspecifiek/EWI/Studeren/Reglementen/TER%20-%20EEMCS%20Faculty%202025-2026%20FINAL.pdf) Page 26, Footnote 4.). When the student decides to follow the course again, there will be no penalty for doing so, i.e. grade $F$ (or sub-grades $P$, $E$, and $R$) at the next course edition will not be upper-bounded becuase of a previous years' course grade failure.
+* _Group Project_: In case of grade $P$ for the group project being lower than 5.75 or a student wants to improve the grade $P$, the student must register for the course in the next academic year to repair the grade. In other words, there will be no repair assignment for the group project. This is because the group project will span the whole course time and it will be unreasonable to ask the student to do a failed project in even less time than the academic quarter (see [TU Delft Faculty of Electrical Engineering, Mathematics and Computer Science Teaching and Examination Regulations 2025-2026](https://filelist.tudelft.nl/Studentenportal/Faculteitspecifiek/EWI/Studeren/Reglementen/TER%20-%20EEMCS%20Faculty%202025-2026%20FINAL.pdf) Page 26, Footnote 4.). When the student decides to follow the course again, there will be no penalty for doing so, i.e. grade $F$ (or sub-grades $P$, $E$, and $R$) at the next course edition will not be upper-bounded because of a previous years' course grade failure.
 
-* _Written Exam_: In case of grade $E$ for the group project being lower than 5.75 or a student wants to improve the grade $E$, the course will offer a resit opportunity. For the final grade $E$, the highest of the two grades (initilal exam and resit exam) will be taken. Both first and resit exam will have the same format.
+* _Written Exam_: In case of grade $E$ for the group project being lower than 5.75 or a student wants to improve the grade $E$, the course will offer a resit opportunity. For the final grade $E$, the highest of the two grades (initial exam and resit exam) will be taken. Both the initial and resit exam will have the same format.
 
 ### Group project
 
@@ -139,7 +139,7 @@ To better understand what we want from your report, we have decided to share the
 
 ## This Course is Looking for Your Feedback
 
-The course is in a continous development, so it will be updated after every iteration. We request all followers of this course to suggest changes and improvemens by submitting issues. We appreciate your ideas and criticism.
+The course is in a continuous development, so it will be updated after every iteration. We request all followers of this course to suggest changes and improvements by submitting issues. We appreciate your ideas and criticism.
 
 There is also a link after every lecture and inside every module of this repository where you can send your feedback.
 
@@ -172,10 +172,10 @@ Have a question for us? Do not hesitate to contact us at our official course e-m
   * Answer: No. However it does not mean you should skip the guest lectures: they will be equally informative and learning as the main course. The added value of the guest lectures (and what should make them appealing) is to learn about the topic of the lecture from the ICT practitioners from the industry. The intended educational value of offering such lectures is knowledge expansion and knowledge deepening.
 
 * Question: __What if I need to drop the lecture mid-way?__
-  * Answer: You are free do to so (of course you will not get a passing grade), but please be aware that with that you will cause problems to your project teammates, so please be sure that you are really able to be present until the last day of the course.
+  * Answer: You are free to do so (of course you will not get a passing grade), but please be aware that with that you will cause problems to your project teammates, so please be sure that you are really able to be present until the last day of the course.
 
-* Question: __Will the video material from the classess be eventually available?__
-  * Answer: Yes, we are working on it, but expect the videos be available not earlier than from 2026/2027 academic year.
+* Question: __Will the video material from the classes be eventually available?__
+  * Answer: Yes, we are working on it, but expect the videos to be available no earlier than the 2026/2027 academic year.
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All lectures will be given physically at TU Delft, except for guest lectures whi
   	* [TU Delft EEMCS Hall F (36.HB.00.260)](https://esviewer.tudelft.nl/space/55/) lecture room
 
 * _11 September 2025 15:45-17:45 (Week 2: Definitions and Project Start)_
-  * Lecture 2: __[Defining Sustainability]()__
+  * Lecture 2: __[Defining Sustainability](https://github.com/TUDSSL/dsicts/tree/main/Lectures/Lecture%202%20-%20Defining%20Sustainability)__
     * [TU Delft EEMCS Hall F (36.HB.00.260)](https://esviewer.tudelft.nl/space/55/) lecture room
 
 * _12 September 2025 15:45-17:45 (Week 2: Definitions and Project Start)_
@@ -60,18 +60,18 @@ All lectures will be given physically at TU Delft, except for guest lectures whi
     * [TU Delft EEMCS Hall G (36.HB.00.230)](https://esviewer.tudelft.nl/space/181/) lecture room
 
 * _18 September 2025 15:45-17:45 (Week 3: Software)_
-  * Lecture 3: __[Sustainable Software]()__
+  * Lecture 3: __[Sustainable Software](https://github.com/TUDSSL/dsicts/tree/main/Lectures/Lecture%203%20-%20Sustainable%20Software)__
     * [TU Delft EEMCS Hall F (36.HB.00.260)](https://esviewer.tudelft.nl/space/55/) lecture room
 
 * _19 September 2025 15:45-17:45 (Week 3: Software)_
   * Guest lecture 1: __[To Be Announced]__ (to be confirmed)
     * [online]
 
-* _25 September 2025 15:45-17:45 (Week 4: Cloud Computing)_
-  * Lecture 4: __[Sustainable Cloud Computing]()__
+* _25 September 2025 15:45-17:45 (Week 4: Sustainable Artificial Intelligence)_
+  * Lecture 4: __[Sustainable Artificial Intelligence](https://github.com/TUDSSL/dsicts/tree/main/Lectures/Lecture%204%20-%20Sustainable%20AI)__
     * [TU Delft EEMCS Hall F (36.HB.00.260)](https://esviewer.tudelft.nl/space/55/) lecture room
 
-* _26 September 2025 15:45-17:45 (Week 4: Cloud Computing)_
+* _26 September 2025 15:45-17:45 (Week 4: Sustainable Artificial Intelligence)_
   * No lecture
 
 * _02 October 2025 15:45-17:45 (Week 5: Group Work on the Projects)_
@@ -82,15 +82,15 @@ All lectures will be given physically at TU Delft, except for guest lectures whi
   * __Group Projects Midterm Presentations__ (backup session)
     * [TU Delft EEMCS Hall G (36.HB.00.230)](https://esviewer.tudelft.nl/space/181/) lecture room
 
-* _09 October 2025 15:45-17:45 (Week 6: Sustainable Artificial Intelligence)_
-  * Lecture 5: __[Sustainable Artificial Intelligence]()__
+* _09 October 2025 15:45-17:45 (Week 6: Sustainable Cloud Computing)_
+  * Lecture 5: __[Sustainable Cloud Computing](https://github.com/TUDSSL/dsicts/tree/main/Lectures/Lecture%205%20-%20Sustainable%20Cloud%20Computing)__
     * [TU Delft EEMCS Hall F (36.HB.00.260)](https://esviewer.tudelft.nl/space/55/) lecture room
 
-* _10 October 2025 15:45-17:45 (Week 6: Sustainable Artificial Intelligence)_
+* _10 October 2025 15:45-17:45 (Week 6: Sustainable Cloud Computing)_
   * No lecture
 
 * _16 October 2025 15:45-17:45 (Week 7: Sustainable Electronics Design)_
-  * Lecture 6: Lecture __[Sustainable Electronics Design]()__
+  * Lecture 6: Lecture __[Sustainable Electronics Design](https://github.com/TUDSSL/dsicts/tree/main/Lectures/Lecture%206%20-%20Sustainable%20Electronics)__
     * [TU Delft EEMCS Hall F (36.HB.00.260)](https://esviewer.tudelft.nl/space/55/) lecture room
 
 * _17 October 2025 15:45-17:45 (Week 7: Sustainable Electronics Design)_


### PR DESCRIPTION
### Summary
This pull request fixes some minor issues in the course README:

   - Filled in missing links in the schedule that should point to the lectures
   - Swapped Week 4 and Week 6 naming to adhere to the schedule and the uploaded lecture links
   - Fixed spelling mistakes

### Motivation
These changes make the materials easier to read and more consistent. 
No content meaning or technical information has been altered.