### PR TITLE
Change wording to reflect research usage of this term

### DIFF
--- a/Lectures/Lecture 3 - Sustainable Software/Lecture 3 Notes.md
+++ b/Lectures/Lecture 3 - Sustainable Software/Lecture 3 Notes.md
@@ -29,7 +29,7 @@ This can be used when power is not consistent over time. You average the power i
 
 Average power can easily be converted to energy via the formula:
 $$ E = P_{\text{average}}\Delta t$$
-#### Energy Delayed Product (EDP)
+#### Energy-Delay Product (EDP)
 Next to energy consumption, this metric additionally considers the time taken to run an application. Consequently, it favors applications which minimize energy consumption **and** the runtime.
 $$EDP = E  t =\Delta P  t^2 $$
 


### PR DESCRIPTION
In the relevant research, "energy-delay product" is used, not "energy delayed product".